### PR TITLE
Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A configuration file is stored at [metrics.yml](config/metrics.yml). And has the
 - `metrics`: List of metrics (data-collector uses the job summaries UUIDs to pull these metrics) to normalize
   - `name`: Name of the metric, i.e: `metricName.keyword: metric_name_in_config`
   - `value_field`: Name of the field that contains the value, defaults to `value`
+  - `rename`: Field name to rename
   - `description`: Description of the metric, will be added to the normalized output
 - `skip_metrics`: Metrics with the following fields will be skipped:
 - `discard_fields`: List of fields to discard from normalized output.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ pip install -r requirements.txt
 python setup.py install
 ```
 
-## Features
+## Running
 
-TODO
+```
+$ data_collector -es-server 'https://elastic-search-fqdn' --es-index 'kube-burner*' --config config/metrics.yml --from $(date -d "2 months ago" +%s)
+```
+
+## Configuration
+
+A configuration file is stored at [metrics.yml](config/metrics.yml). And has the following directives:
+
+- `metadata`: List of metadata fields to process from the fetched job summaries.
+- `job_summary_filters`: List of filters to apply to the job summaries query.
+- `metrics`: List of metrics (data-collector uses the job summaries UUIDs to pull these metrics) to normalize
+  - `name`: Name of the metric, i.e: `metricName.keyword: metric_name_in_config`
+  - `value_field`: Name of the field that contains the value, defaults to `value`
+  - `description`: Description of the metric, will be added to the normalized output
+- `skip_metrics`: Metrics with the following fields will be skipped:
+- `discard_fields`: List of fields to discard from normalized output.
+- `output_prefix`: Prefix for the output file
+- `s3_bucket`: Name of the S3 bucket
+- `s3_folder`: Name of the S3 folder
+- `chunk_size`: Size of the chunks (number of lines) to upload to S3

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -15,7 +15,6 @@ metadata:
 - iterationsPerNamespace
 - jobIterations
 - jobType
-- maxWaitTimeout
 - metricsClosing
 - verifyObjects
 - waitForDeletion
@@ -50,7 +49,7 @@ skip_metrics:
   churnMetric: true
   jobName.keyword: garbage-collection
   jobConfig.name.keyword: garbage-collection
-discardFields: [P95, P90, P50, max, min, avg, metadata, uuid, timestamp, query, uuid]
+discard_fields: [P95, P90, P50, max, min, avg, metadata, uuid, timestamp, query, uuid]
 output_prefix: output
 s3_folder: cluster-density-v2
 s3_bucket: kube-burner-ai-s3-bucket

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -1,10 +1,10 @@
 metadata:
 - clusterType
 - controlPlaneArch
-- elapsedTime
 - infraNodesCount
 - infraNodesType
 - ipsecMode
+- qps
 - burst
 - churnCycles
 - churnDelay
@@ -17,65 +17,39 @@ metadata:
 - jobType
 - maxWaitTimeout
 - metricsClosing
-- name
-- preLoadPeriod
-- qps
 - verifyObjects
 - waitForDeletion
 - waitWhenFinished
 - k8sVersion
 - masterNodesCount
 - masterNodesType
-- metricName
 - ocpMajorVersion
 - ocpVersion
 - passed
 - platform
-- publish
 - region
 - sdnType
 - totalNodes
-- uuid
 - workerArch
 - workerNodesCount
 - workerNodesType
+skip_metrics:
+  churnMetric: true
+  jobName.keyword: garbage-collection
+  jobConfig.name.keyword: garbage-collection
+job_summary_filters:
+  platform.keyword: AWS
+  jobConfig.name.keyword: cluster-density-v2
 metrics:
-- alert
-# - avg-ro-apicalls-latency
-# - avg-mutating-apicalls-latency
-# - 99thEtcdDiskBackendCommit
-# - 99thEtcdDiskWalFsync
-# - 99thEtcdRoundTripTime
-# - cpu-kube-controller-manager
-# - max-memory-sum-kube-controller-manager
-# - cpu-etcd
-# - max-memory-sum-etcd
-- cpu-kube-apiserver
-- max-memory-sum-kube-apiserver
-- cpu-masters
-- max-memory-sum-masters
-- cpu-workers
-- max-memory-sum-workers
-- podLatencyQuantilesMeasurement
-benchmark: cluster-density-v2
-exclude_normalization:
-- LatencyMeasurement
-- jobSummary
-- nodeRoles
-- nodeStatus
-- alert
-- -start
-target_filters_by_data:
-- platform: AWS
-target_field_extract_filters:
-# - "^avg-ro-apicalls-latency": '^avg-ro-apicalls-latency.*_byLabelScope_resource(?:_|$).*'
-# - "^avg-ro-apicalls-latency": '^avg-ro-apicalls-latency.*_byLabelScope_namespace(?:_|$).*'
-# - "^avg-mutating-apicalls-latency": '^avg-mutating-apicalls-latency.*_byLabelScope_resource(?:_|$).*'
-# - "^avg-mutating-apicalls-latency": '^avg-mutating-apicalls-latency.*_byLabelScope_namespace(?:_|$).*'
-- "^podLatencyQuantilesMeasurement": 'podLatencyQuantilesMeasurement_Ready_P99'
-# target_fields_to_reduce:
-# - '^avg-ro-apicalls-latency.*_byLabelScope_resource(?:_|$).*': "avg-ro-apicalls-latency_byLabelScope_resource"
-# - '^avg-ro-apicalls-latency.*_byLabelScope_namespace(?:_|$).*': "avg-ro-apicalls-latency_byLabelScope_namespace"
-# - '^avg-mutating-apicalls-latency.*_byLabelScope_resource(?:_|$).*': "avg-mutating-apicalls-latency_byLabelScope_resource"
-# - '^avg-mutating-apicalls-latency.*_byLabelScope_namespace(?:_|$).*': "avg-mutating-apicalls-latency_byLabelScope_namespace"
+  - name: podLatencyQuantilesMeasurement
+    value_field: P99
+    description: "The pod latency quantiles"
+  - name: cpu-kube-apiserver
+  - name: max-memory-sum-kube-apiserver
+  - name: cpu-masters
+  - name: max-memory-sum-masters
+  - name: cpu-workers
+  - name: max-memory-sum-workers
+discardFields: [P95, P90, P50, max, min, avg, metadata, uuid, timestamp, query, uuid]
 output_prefix: output
+s3_folder_name: cluster-density-v2

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -38,6 +38,8 @@ job_summary_filters:
 metrics:
   - name: podLatencyQuantilesMeasurement
     value_field: P99
+    rename:
+      quantileName: metricName
     description: "The pod latency quantiles"
   - name: cpu-kube-apiserver
   - name: max-memory-sum-kube-apiserver

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -33,10 +33,6 @@ metadata:
 - workerArch
 - workerNodesCount
 - workerNodesType
-skip_metrics:
-  churnMetric: true
-  jobName.keyword: garbage-collection
-  jobConfig.name.keyword: garbage-collection
 job_summary_filters:
   platform.keyword: AWS
   jobConfig.name.keyword: cluster-density-v2
@@ -50,6 +46,12 @@ metrics:
   - name: max-memory-sum-masters
   - name: cpu-workers
   - name: max-memory-sum-workers
+skip_metrics:
+  churnMetric: true
+  jobName.keyword: garbage-collection
+  jobConfig.name.keyword: garbage-collection
 discardFields: [P95, P90, P50, max, min, avg, metadata, uuid, timestamp, query, uuid]
 output_prefix: output
-s3_folder_name: cluster-density-v2
+s3_folder: cluster-density-v2
+s3_bucket: kube-burner-ai-s3-bucket
+chunk_size: 10000

--- a/data_collector/collector.py
+++ b/data_collector/collector.py
@@ -57,7 +57,6 @@ class Collector:
 
                 if not hits:
                     break
-
                 for hit in hits:
                     run_data = {}
                     jobSummary = hit.to_dict()
@@ -88,7 +87,6 @@ class Collector:
 
                     data.append(run_data)
                     total_hits += 1
-
                 # Prepare for next page
                 search_after = hits[-1].meta.sort
 
@@ -103,16 +101,23 @@ class Collector:
     def _metrics_by_uuid(self, uuid: str):
         """Collects the list of metrics for an uuid"""
         metrics = {}
-        input_list = self.config.get("metrics", {})
-        metric_filter = [Q("term", **{"metricName.keyword": metric}) for metric in input_list]
-        should_query = Q("bool", should=metric_filter)
-        query = Q("bool", must_not=[Q("term", **{"jobConfig.name.keyword": "garbage-collection"})], should=should_query)
+        must_not_filter = []
+        metrics_list = self.config.get("metrics", {})
+        metric_filter = [
+            Q("term", **{"metricName.keyword": metric["name"]})
+            for metric in metrics_list
+        ]
+        must_not_filter = [
+            Q("term", **{k: v})
+            for k, v in self.config.get("skipMetrics", {}).items()
+        ]
+        query = Q("bool", should=metric_filter, must_not=must_not_filter)
         s = Search(using=self.os_client, index=self.es_index).filter("term", **{"uuid.keyword": uuid}).query(query)
-        logger.info(f"Running query: {s.to_dict()}")
+        logger.debug(f"Running query: {s.to_dict()}")
         for hit in s.scan():
             datapoint = hit.to_dict()
             if datapoint["metricName"] not in metrics:
                 metrics[datapoint["metricName"]] = [datapoint]
             else:
                 metrics[datapoint["metricName"]].append(datapoint)
-        return metrics, len(metrics) == len(input_list)
+        return metrics, len(metrics) == len(metrics_list)

--- a/data_collector/constants.py
+++ b/data_collector/constants.py
@@ -1,3 +1,1 @@
-S3_BUCKET = "kube-burner-ai-s3-bucket"
-CHUNK_SIZE = 10000
 VALID_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/data_collector/normalize.py
+++ b/data_collector/normalize.py
@@ -32,7 +32,7 @@ def normalize(metrics_data: Dict, config: Dict) -> pd.DataFrame:
     """
     run_df = pd.DataFrame()
     metadata = metrics_data.pop("metadata", {})
-    jobConfig = metadata.pop("jobConfig", {})
+    job_config = metadata.pop("jobConfig", {})
     for metric_name, metric_samples in metrics_data["metrics"].items():
         for metric in config["metrics"]:
             if metric["name"] == metric_name:
@@ -50,7 +50,7 @@ def normalize(metrics_data: Dict, config: Dict) -> pd.DataFrame:
             else:
                 aggregated_metric_samples["value"] += metric_sample["value"] / 2
         aggregated_metric_samples.update(metadata)
-        aggregated_metric_samples.update(jobConfig)
+        aggregated_metric_samples.update(job_config)
         aggregated_metric_samples["cluster_health_score"] = get_cluster_health(aggregated_metric_samples["passed"], aggregated_metric_samples.pop("execution_errors", ""))
         aggregated_metric_samples["description"] = metric_config.get("description", "")
         # We convert the list of dictionaries into a DataFrame

--- a/data_collector/normalize.py
+++ b/data_collector/normalize.py
@@ -49,6 +49,7 @@ def normalize(metrics_data: Dict, config: Dict) -> pd.DataFrame:
                 aggregated_metric_samples = metric_sample
             else:
                 aggregated_metric_samples["value"] += metric_sample["value"] / 2
+        rename_metric_field(metric_config, aggregated_metric_samples)
         aggregated_metric_samples.update(metadata)
         aggregated_metric_samples.update(job_config)
         aggregated_metric_samples["cluster_health_score"] = get_cluster_health(aggregated_metric_samples["passed"], aggregated_metric_samples.pop("execution_errors", ""))
@@ -57,3 +58,9 @@ def normalize(metrics_data: Dict, config: Dict) -> pd.DataFrame:
         df = pd.DataFrame([aggregated_metric_samples])
         run_df = pd.concat([run_df, df], ignore_index=True)
     return run_df
+
+
+def rename_metric_field(metric_config: Dict, metric_sample: Dict):
+    for k, v in metric_config.get("rename", {}).items():
+        if k in metric_sample:
+            metric_sample[v] = metric_sample.pop(k)

--- a/data_collector/normalize.py
+++ b/data_collector/normalize.py
@@ -1,222 +1,59 @@
-import re
 import logging
-import numpy as np
-import pandas as pd
-from typing import Dict, List
+from typing import Dict
 from data_collector.utils import (
-    strhash,
-    should_exclude,
-    compile_exclude_patterns,
-    recursively_flatten_values,
-    remove_keys_by_patterns,
-    flatten_json,
+    recursively_flatten_dict
 )
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-DROP_LIST = ['metadata','uuid','metricName','labels','query', 'value', 'jobName', 'timestamp']
-NEST_ORDER = ["mode", "scope", "verb", "namespace", "component", "resource", "container", "endpoint"]
-DEFAULT_HASH = "xyz"
-
-
-def process_json(metric: str, entries: dict, skip_patterns: List[re.Pattern], output: Dict) -> None:
-    """Processes JSON and generates a huge json with minimal data"""
-    if not entries:
-        return
-
-    metric_name = entries[0].get("metricName")
-    if not metric_name:
-        logger.info(f"Warning: 'metricName' missing in first entry of the metric: {metric}")
-        return
-
-    if should_exclude(metric_name, skip_patterns):
-        return
-
-    grouped_metrics = {}
-    for entry in entries:
-        # Skip the metircs during churn phase to avoid noise
-        if 'churnMetric' in entry:
-            continue
-        # Skip metrics during garbage collection as well to avoid noise
-        if 'jobName' in entry and entry['jobName'].lower() == 'garbage-collection':
-            continue
-        label_hash = DEFAULT_HASH
-        labels = entry.get("labels")
-        if labels:
-            label_hash = strhash(labels)
-
-        if label_hash not in grouped_metrics:
-            grouped_metrics[label_hash] = {"value": 0.0}
-            if labels:
-                grouped_metrics[label_hash]["labels"] = {k: labels[k] for k in NEST_ORDER if k in labels}
-
-        # Drop unneeded fields
-        if "value" in entry:
-            # reduces value to average
-            entry = {"value": entry["value"]}
-            grouped_metrics[label_hash]["value"] += entry["value"]/2
-        else:
-            # handles cases where metrics don't have value. for example, quantiles
-            for k in DROP_LIST:
-                entry.pop(k,None)
-            # Need to deal with this edge case as we set {"value": 0.0} as default above
-            if isinstance(grouped_metrics[label_hash]["value"], (int, float)):
-                grouped_metrics[label_hash].pop("value", None)
-            if "value" not in grouped_metrics[label_hash]:
-                grouped_metrics[label_hash]["value"] = [entry]
-            else:
-                grouped_metrics[label_hash]["value"].append(entry)
-
-    # Adds up condensed data values to output json
-    if metric_name in output["metrics"]:
-        output["metrics"][metric_name].extend(grouped_metrics.values())
-    else:
-        output["metrics"][metric_name] = list(grouped_metrics.values())
-
-def normalize_metrics(metrics: dict) -> dict:
-    """Intermidiate normalization step to further reduce the json"""
-
-    # Labels precedence order used for nesting
-    nested_metrics = {}
-
-    for metric, entries in metrics:
-        nested_metrics.setdefault(metric, {})
-
-        for entry in entries:
-            labels = entry.get("labels", {})
-            value = entry["value"]
-
-            # Get available keys from labels, in nest_order
-            label_keys = [k for k in NEST_ORDER if k in labels]
-            if not label_keys:
-                # No labels at all, store directly under metric
-                existing = nested_metrics[metric]
-                if isinstance(existing, (int, float)):
-                    nested_metrics[metric] = (existing + value) / 2
-                elif isinstance(existing, dict):
-                    if "_value" in nested_metrics[metric]:
-                        nested_metrics[metric]["_value"] = (nested_metrics[metric]["_value"] + value) / 2
-                    else:
-                        nested_metrics[metric]["_value"] = value
-                else:
-                    nested_metrics[metric] = value
-                continue
-
-            curr = nested_metrics[metric]
-            for _, key in enumerate(label_keys):
-                # logc to generate nested keys with labels
-                key_value = labels[key]
-                group_key = f"byLabel{key.capitalize()}"
-                curr = curr.setdefault(group_key, {})
-                if key_value in curr:
-                    if isinstance(curr[key_value], (int, float)):
-                        curr[key_value] = {"_value": curr[key_value]}
-                    curr = curr[key_value]
-                else:
-                    curr = curr.setdefault(key_value, {})
-
-            # Now we're at the leaf, insert _value
-            if "_value" in curr:
-                curr["_value"] = (curr["_value"] + value) / 2
-            else:
-                curr["_value"] = value
-
-    return nested_metrics
-
-def get_cluster_health(alerts: list, passed: bool) -> str:
+def get_cluster_health(passed: bool, execution_errors: str) -> str:
     """Calculates and returns cluster health"""
-    has_error, has_warning = False, False
-    for alert in alerts:
-        if alert["severity"].lower() == 'warning':
-            has_warning = True
-        if alert["severity"].lower() == 'error':
-            has_error = True
-    if has_error or not passed:
+    if not passed:
         return "Red"
-    if has_warning:
+    if execution_errors:
         return "Yellow"
     return "Green"
 
-def normalize(metrics_data, data_filters, extract_filters, fields_to_reduce: dict, exclude_metrics: str):
-    """Driver code to triger the execution"""
-    skip_patterns = compile_exclude_patterns(exclude_metrics)
+def normalize(metrics_data: Dict, config: Dict) -> pd.DataFrame:
+    """
+    Normalize data from a job run.
 
-    merged_output = {"metrics": {}}
+    This function takes the metrics data from a job run and normalizes it into a
+    pandas DataFrame. It also adds the cluster health score to the resulting
+    DataFrame.
 
-    for metric, value in metrics_data["metrics"].items():
-        process_json(metric, value, skip_patterns, merged_output)
+    Args:
+        metrics_data (Dict): The data from a job run.
+        config (Dict): The configuration for the job.
 
-    nested_metrics = normalize_metrics(merged_output["metrics"].items())
-
-    final_output = recursively_flatten_values(nested_metrics)
-
-    flattened = {}
-    flatten_json(flattened, final_output)
-    patterns_to_remove = [r"(?i).*time.*", r"uuid", r"version"]
-    metadata = remove_keys_by_patterns(metrics_data["metadata"], patterns_to_remove)
-    for key, value in metadata.items():
-        if "jobConfig" != key:
-            flattened[key] = value
-        else:
-            for key, value in metadata.get("jobConfig", {}).items():
-                flattened[f"jobConfig.{key}"] = value
-
-    # Filter rows by data filters (e.g., platform == AWS)
-    has_atleast_one_filter = False
-    if data_filters:
-        for filter in data_filters:
-            key, value = list(filter.items())[0]
-            if flattened.get(key) ==  value:
-                has_atleast_one_filter = True
-                break
-    if not has_atleast_one_filter:
-        return {}
-
-    # Extract matching fields (based on regex)
-    fields_to_keep = set()
-    fields_with_prefix = set()
-    if extract_filters:
-        for extract_filter in extract_filters:
-            key, value = list(extract_filter.items())[0]
-            key_pattern = re.compile(key)
-            value_pattern = re.compile(value)
-            for field in flattened.keys():
-                if key_pattern.match(field):
-                    fields_with_prefix.add(field)
-                    if value_pattern.match(field):
-                        fields_to_keep.add(field)
-    flattened = {k: v for k, v in flattened.items() if k not in fields_with_prefix - fields_to_keep}
-
-    # Reduce multiple fields into one target (based on regex)
-    if fields_to_reduce:
-        for field in fields_to_reduce:
-            key, target_key = list(field.items())[0]
-
-            # Find all matching keys
-            matching_items = {k: v for k, v in flattened.items() if re.match(key, k)}
-
-            if not matching_items:
-                continue
-
-            # Collect valid values
-            values = [v for v in matching_items.values() if v is not None and str(v) != "nan"]
-            if not values:
-                flattened[target_key] = None
+    Returns:
+        pd.DataFrame: The normalized DataFrame.
+    """
+    run_df = pd.DataFrame()
+    metadata = metrics_data.pop("metadata", {})
+    jobConfig = metadata.pop("jobConfig", {})
+    for metric_name, metric_samples in metrics_data["metrics"].items():
+        for metric in config["metrics"]:
+            if metric["name"] == metric_name:
+                metric_config = metric
+        aggregated_metric_samples = {}
+        for metric_sample in metric_samples:
+            if "value_field" in metric_config:
+                metric_sample["value"] = metric_sample.pop(metric_config["value_field"])
+            metric_sample = recursively_flatten_dict(metric_sample)
+            # metadata and job config must be added to the flattened and averaged result
+            for field in config.get("discard_fields", []):
+                metric_sample.pop(field, None)
+            if not aggregated_metric_samples:
+                aggregated_metric_samples = metric_sample
             else:
-                try:
-                    numeric_vals = pd.to_numeric(values, errors="coerce").dropna()
-                    if len(numeric_vals) > 0:
-                        flattened[target_key] = float(np.mean(numeric_vals))  # average
-                    else:
-                        flattened[target_key] = pd.Series(values).median()  # median
-                except Exception:
-                    flattened[target_key] = pd.Series(values).median()
-
-            # Drop the original matching keys, since we replaced them
-            for k in matching_items.keys():
-                if k != target_key:  # avoid removing the reduced one
-                    flattened.pop(k, None)
-
-    alerts = metrics_data["metrics"]["alert"] if 'alert' in metrics_data["metrics"] else []
-    flattened["cluster_health_score"] = get_cluster_health(alerts, metadata["passed"])
-    return flattened
+                aggregated_metric_samples["value"] += metric_sample["value"] / 2
+        aggregated_metric_samples.update(metadata)
+        aggregated_metric_samples.update(jobConfig)
+        aggregated_metric_samples["cluster_health_score"] = get_cluster_health(aggregated_metric_samples["passed"], aggregated_metric_samples.pop("execution_errors", ""))
+        aggregated_metric_samples["description"] = metric_config.get("description", "")
+        # We convert the list of dictionaries into a DataFrame
+        df = pd.DataFrame([aggregated_metric_samples])
+        run_df = pd.concat([run_df, df], ignore_index=True)
+    return run_df

--- a/data_collector/output.py
+++ b/data_collector/output.py
@@ -23,3 +23,8 @@ def upload_csv_to_s3(chunk_df: pd.DataFrame, bucket, foldername, filename):
         tmp.close()
         os.remove(tmp.name)
         logger.info(f"🧹 Temporary file {tmp.name} deleted")
+
+def write_to_file(chunk_df: pd.DataFrame, filename: str):
+    with open(filename, "w") as f:
+        chunk_df.to_csv(f, index=False)
+    logger.info(f"✅ Output written in file {filename}")

--- a/data_collector/s3.py
+++ b/data_collector/s3.py
@@ -3,16 +3,15 @@ import csv
 import boto3
 import logging
 import tempfile
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-def upload_csv_to_s3(chunk_rows, fieldnames, bucket, foldername, filename):
+def upload_csv_to_s3(chunk_df: pd.DataFrame, bucket, foldername, filename):
     """Uploads a CSV file to S3"""
     tmp = tempfile.NamedTemporaryFile(mode='w+', newline='', delete=False)
     try:
-        writer = csv.DictWriter(tmp, fieldnames=fieldnames)
-        writer.writeheader()
-        writer.writerows(chunk_rows)
+        chunk_df.to_csv(tmp, index=False)
         tmp.flush()
 
         # Upload to S3

--- a/data_collector/utils.py
+++ b/data_collector/utils.py
@@ -5,10 +5,10 @@ from typing import Dict, List, Any
 
 logger = logging.getLogger(__name__)
 
-def split_list_into_chunks(lst, chunk_size):
+def split_list_into_chunks(df, chunk_size):
     """Splits a list into given chunk sizes"""
-    for idx in range(0, len(lst), chunk_size):
-        yield lst[idx:idx + chunk_size]
+    for idx in range(0, len(df), chunk_size):
+        yield df[idx:idx + chunk_size]
 
 
 def parse_timerange(from_date_dt: datetime, to_dt: datetime):

--- a/data_collector/utils.py
+++ b/data_collector/utils.py
@@ -10,11 +10,6 @@ def split_list_into_chunks(lst, chunk_size):
     for idx in range(0, len(lst), chunk_size):
         yield lst[idx:idx + chunk_size]
 
-def strhash(value: Any) -> str:
-    """Recursively generate a stable string hash from a nested dict or value"""
-    if isinstance(value, dict):
-        return ''.join(f"{key}:{strhash(value[key])}" for key in sorted(value))
-    return str(value)
 
 def parse_timerange(from_date_dt: datetime, to_dt: datetime):
     """pareses dates and returns UTC formats"""
@@ -47,42 +42,13 @@ def remove_keys_by_patterns(data: Dict, patterns: List[str]) -> Dict:
         if not any(r.match(k) for r in regexes)
     }
 
-def recursively_flatten_values(obj: dict) -> dict:
-    """Recursively flatten the json structure"""
-    if isinstance(obj, dict):
-        # If the dict is exactly {"_value": ...}, reduce it to the value
-        if list(obj.keys()) == ["_value"]:
-            return obj["_value"]
-
-        # Otherwise, process each item and flatten children if possible
-        new_obj = {}
-        for k, v in obj.items():
-            flattened_v = recursively_flatten_values(v)
-            new_obj[k] = flattened_v
-        return new_obj
-
-    elif isinstance(obj, list):
-        return [recursively_flatten_values(elem) for elem in obj]
-
-    else:
-        return obj
-
-def flatten_json(flattened, obj, parent_key=""):
-    """Flatten a json structure"""
+def recursively_flatten_dict(obj: dict) -> dict:
+    """Recursively flatten the dictionary, if a key is repeated it will be overwritten"""
+    new_dict = {}
     if isinstance(obj, dict):
         for k, v in obj.items():
-            new_key = f"{parent_key}_{k}" if parent_key else k
-            flatten_json(flattened, v, new_key)
-    elif isinstance(obj, list):
-        for i, item in enumerate(obj):
-            # If it's a dict with "quantileName", use that for key suffix
-            if isinstance(item, dict) and "quantileName" in item:
-                name = item["quantileName"]
-                for k, v in item.items():
-                    if k != "quantileName":
-                        new_key = f"{parent_key}_{name}_{k}"
-                        flattened[new_key] = v
+            if isinstance(v, dict):
+                new_dict.update(recursively_flatten_dict(v))
             else:
-                flatten_json(flattened, item, f"{parent_key}_{i}")
-    else:
-        flattened[parent_key] = obj
+                new_dict[k] = v
+    return new_dict

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from data_collector.config import Config
 from data_collector.normalize import normalize
 from data_collector.s3 import upload_csv_to_s3
 from data_collector.utils import split_list_into_chunks, parse_timerange
-from data_collector.constants import S3_BUCKET, CHUNK_SIZE, VALID_LOG_LEVELS
+from data_collector.constants import VALID_LOG_LEVELS
 from data_collector.logging import configure_logging
 import datetime
 
@@ -62,9 +62,9 @@ def main():
             uuid_df = normalize(run_json, input_config)
             df = pd.concat([df, uuid_df], ignore_index=True)
     if not df.empty:
-        for idx, chunk in enumerate(split_list_into_chunks(df, CHUNK_SIZE), start=1):
+        for idx, chunk in enumerate(split_list_into_chunks(df, input_config["chunk_size"]), start=1):
             filename = f"{input_config['output_prefix']}_{from_date.strftime('%Y-%m-%dT%H:%M:%SZ')}_{to.strftime('%Y-%m-%dT%H:%M:%SZ')}_chunk_{idx}.csv"
-            upload_csv_to_s3(chunk, S3_BUCKET, input_config["s3_folder_name"], filename)
+            upload_csv_to_s3(chunk, input_config["s3_bucket"], input_config["s3_folder"], filename)
     return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Type of change

- [x] New feature
- [x] Optimization
- [x] Documentation Update

## Description

 📄 Changes in cmd:

- Execution does not require now the `collect` subcommand

📄 Changes in the configuration processing, described in README.md

- Changes in the configuration structure.
- New configuration options, to improve job summary and metric filtering, field discard and renaming, etc
- New description field, that can be used to add a small description to the metric that will be appended to the final output, not sure how this can be useful, we can remove it though.

📄 Changes in configuration file

- Removed some not relevant metadata fields from jobSummary
- Removed alert from the metric list
- job summaries are not filtered using the config option `job_summary_filters`, which includes the benchmark name `jobConfig.name.keyword` as well.
- s3 options and chunk_size can now be configured from here.

📄 Output changes:

Removed some of the old normalization code and simplify it:

- cluster health is now determined from the `passed` and `executionErrors` fields of the metrics, it does not make sense to process alert documents. since they can hold arbitrary information.
- nested fields in metrics are now flattened directly into the output, it's not needed to concatenate them with the metric name (i.e: `podLatencyQuantilesMeasurement_Ready_P99,` is transformed now to `value`)
- values from timeseries metrics are still averaged, the code has been simplied a bit, but the functionality is similar.
- we transform the list of dictionaries holding the normalized metrics to a pandas Dataframe to simplify csv conversion.

---

Data from the last 3 months available in our s3 bucket

```
$ data_collector --es-server 'blabla' --es-index 'blablabla' --config config/metrics.yml --from $(date -d "3 months ago" +%s) 

/var/home/rsevilla/labs/kube-burner-data-collector/.venv/lib64/python3.13/site-packages/opensearchpy/connection/http_urllib3.py:214: UserWarning: Connecting to https://opensearch.app.intlab.redhat.com:443 using SSL with verify_certs=False is insecure.
  warnings.warn(
2025-09-02 14:45:01,943 [data_collector.collector:collector.py:24] INFO: Elasticsearch index: ospst-ripsaw-kube-burner*
2025-09-02 14:45:01,943 [data_collector.collector:collector.py:35] INFO: Fetching kube-burner job summaries using query: {'bool': {'must': [{'range': {'timestamp': {'gte': '2025-06-02T12:45:01Z', 'lte': '2025-09-02T12:45:01Z'}}}, {'term': {'platform.keyword': 'AWS'}}, {'term': {'jobConfig.name.keyword': 'cluster-density-v2'}}], 'must_not': [{'term': {'jobConfig.name.keyword': 'garbage-collection'}}]}}
2025-09-02 15:30:52,653 [data_collector.collector:collector.py:98] INFO: Data collection completed in 1076.20 seconds. Retrieved 1727 documents.
2025-09-02 15:31:08,113 [botocore.credentials:credentials.py:1352] INFO: Found credentials in shared credentials file: ~/.aws/credentials
2025-09-02 15:31:14,067 [data_collector.s3:s3.py:21] INFO: ✅ Uploaded chunk to s3://kube-burner-ai-s3-bucket/cluster-density-v2/output_2025-06-02T13:12:56Z_2025-09-02T13:12:56Z_chunk_1.csv
2025-09-02 15:31:14,069 [data_collector.s3:s3.py:25] INFO: 🧹 Temporary file /tmp/tmplzb0f9zi deleted
2025-09-02 15:31:16,044 [data_collector.s3:s3.py:21] INFO: ✅ Uploaded chunk to s3://kube-burner-ai-s3-bucket/cluster-density-v2/output_2025-06-02T13:12:56Z_2025-09-02T13:12:56Z_chunk_2.csv
2025-09-02 15:31:16,045 [data_collector.s3:s3.py:25] INFO: 🧹 Temporary file /tmp/tmp33noflmn deleted

```

Example output

```csv

quantileName,metricName,jobName,ocpMajorVersion,ocpVersion,value,clusterType,controlPlaneArch,infraNodesCount,infraNodesType,ipsecMode,k8sVersion,masterNodesCount,masterNodesType,passed,platform,region,sdnType,totalNodes,workerArch,workerNodesCount,workerNodesType,qps,burst,churnDelay,churnDeletionStrategy,churnDuration,churnPercent,cleanup,iterationsPerNamespace,jobIterations,jobType,maxWaitTimeout,verifyObjects,waitForDeletion,waitWhenFinished,cluster_health_score,description,metricsClosing
PodReadyToStartContainers,podLatencyQuantilesMeasurement,cluster-density-v2,4.18,4.18.13,60000.0,rosa,amd64,3.0,r5.xlarge,Disabled,v1.31.8,3,m5.2xlarge,True,AWS,us-west-2,OVNKubernetes,30,amd64,24,m5.2xlarge,20,20,120000000000,default,1200000000000,10,True,1,144,create,18000000000000,True,True,True,Green,The pod latency quantiles,
,max-memory-sum-kube-apiserver,cluster-density-v2,4.18,4.18.13,25073750016.0,rosa,amd64,3.0,r5.xlarge,Disabled,v1.31.8,3,m5.2xlarge,True,AWS,us-west-2,OVNKubernetes,30,amd64,24,m5.2xlarge,20,20,120000000000,default,1200000000000,10,True,1,144,create,18000000000000,True,True,True,Green,,
,max-memory-sum-masters,cluster-density-v2,4.18,4.18.13,91431469056.0,rosa,amd64,3.0,r5.xlarge,Disabled,v1.31.8,3,m5.2xlarge,True,AWS,us-west-2,OVNKubernetes,30,amd64,24,m5.2xlarge,20,20,120000000000,default,1200000000000,10,True,1,144,create,18000000000000,True,True,True,Green,,
,cpu-kube-apiserver,cluster-density-v2,4.18,4.18.13,2.9507766406348037,rosa,amd64,3.0,r5.xlarge,Disabled,v1.31.8,3,m5.2xlarge,True,AWS,us-west-2,OVNKubernetes,30,amd64,24,m5.2xlarge,20,20,120000000000,default,1200000000000,10,True,1,144,create,18000000000000,True,True,True,Green,,
```
