### PR TITLE
[PERFSCALE-4123] add aws ec2 instance to specs mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ python setup.py install
 It can be run from the command line as:
 
 ```shell
-$ data_collector --es-server 'https://elastic-search-fqdn' --es-index 'kube-burner*' --config config/metrics.yml --from $(date -d "2 months ago" +%s)
+$ data_collector --es-server 'https://elastic-search-fqdn' --es-index 'kube-burner*' --config config/metrics.yml --from $(date -d "2 months ago" +%s) --instance-dict data/aws_ec2_instances.json
 ```

--- a/data/aws_ec2_instances.json
+++ b/data/aws_ec2_instances.json
@@ -1,0 +1,8234 @@
+[
+  {
+    "instance_type": "a1.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton Processor",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "a1.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton Processor",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "a1.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton Processor",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "a1.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton Processor",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 2,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "a1.metal",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton Processor",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "a1.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton Processor",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c1.medium",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 1.7,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "c1.xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 7,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "c3.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2680 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 15,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "c3.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2680 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 30,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "c3.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2680 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 60,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "c3.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon E5-2680 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 3.75,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "c3.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2680 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 7.5,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "c4.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2666 v3 (Haswell)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 15,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "c4.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2666 v3 (Haswell)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 30,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "c4.8xlarge",
+    "vCPU": 36,
+    "physical_processor": "Intel Xeon E5-2666 v3 (Haswell)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 60,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "c4.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon E5-2666 v3 (Haswell)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 3.75,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "c4.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2666 v3 (Haswell)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 7.5,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "c5.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 96,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "c5.18xlarge",
+    "vCPU": 72,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 144,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c5.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 192,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c5.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5.9xlarge",
+    "vCPU": 36,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 72,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "c5.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 192,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c5.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 96,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "c5a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 128,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "c5a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 192,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "c5a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 64,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "c5a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5ad.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 96,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "c5ad.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 128,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "c5ad.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 192,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "c5ad.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5ad.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5ad.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 64,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "c5ad.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5ad.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "3.3 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5d.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 96,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "c5d.18xlarge",
+    "vCPU": 72,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 144,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c5d.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 192,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c5d.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5d.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5d.9xlarge",
+    "vCPU": 36,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 72,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "c5d.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5d.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 192,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c5d.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3.4 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c5n.18xlarge",
+    "vCPU": 72,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 192,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "c5n.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 21,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c5n.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 42,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c5n.9xlarge",
+    "vCPU": 36,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 96,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c5n.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 5.25,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c5n.metal",
+    "vCPU": 72,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 192,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "c5n.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8124M",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 10.5,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c6a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 96,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "c6a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c6a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 192,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "c6a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6a.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6a.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 64,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6a.metal",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 96,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "c6g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c6g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "c6g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 2,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6g.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c6g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 96,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 2,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c6gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 96,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 2,
+    "network_performance": "Up to 16 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "c6gn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c6i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 96,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "c6i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c6i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 192,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "c6i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6i.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6i.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6id.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 96,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "c6id.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c6id.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 192,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "c6id.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6id.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6id.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6id.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6id.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6id.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6id.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c6in.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 96,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "c6in.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "c6in.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 192,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "c6in.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 40 Gigabit"
+  },
+  {
+    "instance_type": "c6in.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "c6in.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "c6in.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c6in.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c6in.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "c6in.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "c7a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 96,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "c7a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c7a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 192,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "c7a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7a.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c7a.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c7a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 64,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7a.medium",
+    "vCPU": 1,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 2,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7a.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c7a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 96,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "c7g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "c7g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "c7g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "c7g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "c7g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 2,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7g.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "c7g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 96,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 2,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "c7gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 96,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 16,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 32,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 64,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 4,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 2,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "c7gn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 8,
+    "network_performance": "Up to 40 Gigabit"
+  },
+  {
+    "instance_type": "c7i-flex.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 96,
+    "network_performance": "Up to 18.75 Gigabit"
+  },
+  {
+    "instance_type": "c7i-flex.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c7i-flex.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i-flex.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i-flex.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i-flex.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i-flex.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 96,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "c7i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "c7i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 192,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c7i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 64,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 192,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "c7i.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c7i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c8g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 96,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "c8g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 128,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "c8g.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 192,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "c8g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "c8g.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c8g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "c8g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "c8g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c8g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 2,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c8g.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 192,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "c8g.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c8g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 96,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 128,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 192,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 2,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 192,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c8gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 96,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 128,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 192,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 16,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 384,
+    "network_performance": "600 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 32,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 64,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 4,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 2,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 192,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 384,
+    "network_performance": "600 Gigabit"
+  },
+  {
+    "instance_type": "c8gn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 8,
+    "network_performance": "Up to 40 Gigabit"
+  },
+  {
+    "instance_type": "cc2.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2670",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 60.5,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "cr1.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2670",
+    "clock_speed_ghz": null,
+    "memory": 244,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "d2.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 61,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "d2.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 122,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "d2.8xlarge",
+    "vCPU": 36,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 244,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "d2.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 30.5,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "d3.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "d3.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "d3.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "d3.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "d3en.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 192,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "d3en.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "d3en.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "d3en.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 96,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "d3en.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "d3en.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "d3en.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "dl1.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 768,
+    "network_performance": "4x 100 Gigabit"
+  },
+  {
+    "instance_type": "dl2q.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "f1.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 976,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "f1.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 122,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "f1.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 244,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "f2.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "f2.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 2048,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "f2.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 256,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "g2.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2670 (Sandy Bridge)",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 15,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "g2.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2670 (Sandy Bridge)",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 60,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "g3.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 488,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "g3.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 122,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g3.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 244,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "g3s.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 30.5,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "g4ad.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "g4ad.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g4ad.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g4ad.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 128,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "g4ad.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g4dn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 192,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "g4dn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "g4dn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "g4dn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "g4dn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "g4dn.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "g4dn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "g5.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 192,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "g5.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "g5.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "g5.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g5.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "g5.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "g5.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "g5.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g5g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "g5g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g5g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g5g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "g5g.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "g5g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g6.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 192,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "g6.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "g6.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "g6.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g6.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "g6.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "g6.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "g6.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g6e.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 384,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "g6e.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 512,
+    "network_performance": "35 Gigabit"
+  },
+  {
+    "instance_type": "g6e.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 768,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "g6e.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 64,
+    "network_performance": "Up to 20 Gigabit"
+  },
+  {
+    "instance_type": "g6e.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 1536,
+    "network_performance": "400 Gigabit"
+  },
+  {
+    "instance_type": "g6e.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "g6e.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "g6e.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 32,
+    "network_performance": "Up to 20 Gigabit"
+  },
+  {
+    "instance_type": "g6f.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g6f.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "g6f.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "g6f.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "gr6.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "gr6.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R32",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "gr6f.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "h1.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "h1.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "h1.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "h1.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 128,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "hpc6a.48xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 384,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "hpc6id.32xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "hpc7a.12xlarge",
+    "vCPU": 24,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "3.7 GHz",
+    "memory": 768,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "hpc7a.24xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "3.7 GHz",
+    "memory": 768,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "hpc7a.48xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "3.7 GHz",
+    "memory": 768,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "hpc7a.96xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "3.7 GHz",
+    "memory": 768,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "hpc7g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "hpc7g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "hpc7g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.6 GHz",
+    "memory": 128,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "hs1.8xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2650",
+    "clock_speed_ghz": "2 GHz",
+    "memory": 117,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "i2.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 61,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "i2.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 122,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "i2.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 244,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "i2.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 15,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "i2.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 30.5,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "i3.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 488,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "i3.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 61,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i3.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 122,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i3.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 244,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "i3.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 15.25,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i3.metal",
+    "vCPU": 72,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "i3.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 30.5,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i3en.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "i3en.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "i3en.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i3en.3xlarge",
+    "vCPU": 12,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 96,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i3en.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 192,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "i3en.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i3en.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "i3en.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i3p.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 488,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "i4g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "i4g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12 Gigabit"
+  },
+  {
+    "instance_type": "i4g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i4g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "i4g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i4g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i4i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "28.12 Gigabit"
+  },
+  {
+    "instance_type": "i4i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "i4i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 768,
+    "network_performance": "56.25 Gigabit"
+  },
+  {
+    "instance_type": "i4i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12 Gigabit"
+  },
+  {
+    "instance_type": "i4i.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "i4i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i4i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "i4i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i4i.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "i4i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i7i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 384,
+    "network_performance": "Up to 28 Gigabit"
+  },
+  {
+    "instance_type": "i7i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 512,
+    "network_performance": "Up to 37.5 Gigabit"
+  },
+  {
+    "instance_type": "i7i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 768,
+    "network_performance": "Up to 56.25 Gigabit"
+  },
+  {
+    "instance_type": "i7i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12 Gigabit"
+  },
+  {
+    "instance_type": "i7i.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 1536,
+    "network_performance": "Up to 100 Gigabit"
+  },
+  {
+    "instance_type": "i7i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i7i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 256,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i7i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i7i.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 768,
+    "network_performance": "Up to 56.25 Gigabit"
+  },
+  {
+    "instance_type": "i7i.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 1536,
+    "network_performance": "Up to 100 Gigabit"
+  },
+  {
+    "instance_type": "i7i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 384,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.18xlarge",
+    "vCPU": 72,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 576,
+    "network_performance": "Up to 75 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 768,
+    "network_performance": "Up to 100 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.3xlarge",
+    "vCPU": 12,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 96,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 1536,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 192,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 768,
+    "network_performance": "Up to 100 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 1536,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "i7ie.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i8g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "Up to 28.12 Gigabit"
+  },
+  {
+    "instance_type": "i8g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 512,
+    "network_performance": "Up to 37.5 Gigabit"
+  },
+  {
+    "instance_type": "i8g.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "Up to 56.25 Gigabit"
+  },
+  {
+    "instance_type": "i8g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12 Gigabit"
+  },
+  {
+    "instance_type": "i8g.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "Up to 100 Gigabit"
+  },
+  {
+    "instance_type": "i8g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i8g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 256,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i8g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i8g.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "Up to 56.25 Gigabit"
+  },
+  {
+    "instance_type": "i8g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.18xlarge",
+    "vCPU": 72,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 576,
+    "network_performance": "112.5 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.3xlarge",
+    "vCPU": 12,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 96,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 192,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "i8ge.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "im4gn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "im4gn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "im4gn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "im4gn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "im4gn.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "im4gn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "inf1.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8275CL (Cascade Lake)",
+    "clock_speed_ghz": null,
+    "memory": 192,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "inf1.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8275CL (Cascade Lake)",
+    "clock_speed_ghz": null,
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "inf1.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "Intel Xeon Platinum 8275CL (Cascade Lake)",
+    "clock_speed_ghz": null,
+    "memory": 48,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "inf1.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8275CL (Cascade Lake)",
+    "clock_speed_ghz": null,
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "inf2.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "inf2.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "inf2.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "inf2.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 16,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "is4gen.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 48,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "is4gen.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 96,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "is4gen.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 192,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "is4gen.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 12,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "is4gen.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 6,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "is4gen.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 24,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m1.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 7.5,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "m1.medium",
+    "vCPU": 1,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 3.75,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "m1.small",
+    "vCPU": 1,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 1.7,
+    "network_performance": "Low"
+  },
+  {
+    "instance_type": "m1.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 15,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "m2.2xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 34.2,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "m2.4xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 68.4,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "m2.xlarge",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": null,
+    "memory": 17.1,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "m3.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge/Sandy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 30,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "m3.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge/Sandy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 7.5,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "m3.medium",
+    "vCPU": 1,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge/Sandy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 3.75,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "m3.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge/Sandy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 15,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "m4.10xlarge",
+    "vCPU": 40,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 160,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "m4.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m4.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 32,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "m4.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 64,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "m4.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 8,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "m4.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2676 v3 (Haswell)",
+    "clock_speed_ghz": "2.4 GHz",
+    "memory": 16,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "m5.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 192,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "m5.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "m5.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m5.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "m5.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m5.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 192,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "m5a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "m5a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "m5a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5ad.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 192,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "m5ad.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "m5ad.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "m5ad.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5ad.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5ad.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5ad.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5ad.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5d.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 192,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "m5d.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "m5d.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m5d.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5d.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5d.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "m5d.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5d.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m5d.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 192,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m5dn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5n.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 192,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m5n.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "m5n.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m5n.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5n.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5n.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m5n.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5n.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m5n.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5zn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 192,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m5zn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5zn.3xlarge",
+    "vCPU": 12,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 48,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5zn.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 96,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m5zn.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m5zn.metal",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 192,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m5zn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m6a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 192,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "m6a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m6a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 384,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "m6a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6a.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 512,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6a.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 128,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6a.metal",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 192,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "m6g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m6g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 128,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "m6g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6g.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m6g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": null,
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 192,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m6gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "m6i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 192,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "m6i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m6i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "m6i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6i.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6i.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6id.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 192,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "m6id.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m6id.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "m6id.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6id.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6id.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6id.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6id.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6id.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6id.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 192,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 40 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "m6idn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "m6in.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 192,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "m6in.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m6in.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "m6in.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 40 Gigabit"
+  },
+  {
+    "instance_type": "m6in.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "m6in.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "m6in.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m6in.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m6in.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "m6in.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "m7a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 192,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "m7a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m7a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 384,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "m7a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7a.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 512,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m7a.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m7a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 128,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7a.medium",
+    "vCPU": 1,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7a.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m7a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 192,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "m7g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "m7g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m7g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m7g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "m7g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7g.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "m7g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 192,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "m7gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i-flex.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 192,
+    "network_performance": "Up to 18.75 Gigabit"
+  },
+  {
+    "instance_type": "m7i-flex.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "m7i-flex.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i-flex.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i-flex.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i-flex.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i-flex.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 192,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "m7i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "m7i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 384,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m7i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 128,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 384,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "m7i.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m7i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 192,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "m8g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 256,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "m8g.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "m8g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8g.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m8g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 128,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "m8g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8g.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "m8g.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m8g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 192,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 256,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 128,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 4,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m8gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8i-flex.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 192,
+    "network_performance": "Up to 22.5 Gigabit"
+  },
+  {
+    "instance_type": "m8i-flex.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 256,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "m8i-flex.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8i-flex.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8i-flex.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8i-flex.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8i-flex.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 192,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "m8i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 256,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "m8i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 384,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "m8i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 32,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8i.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 512,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "m8i.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 768,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "m8i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "m8i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 128,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "m8i.96xlarge",
+    "vCPU": 384,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 1536,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m8i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "m8i.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 768,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "m8i.metal-96xl",
+    "vCPU": 384,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 1536,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "m8i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "mac-m4.metal",
+    "vCPU": 10,
+    "physical_processor": "Apple silicon m4",
+    "clock_speed_ghz": "4.4 GHz",
+    "memory": 24,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "mac-m4pro.metal",
+    "vCPU": 14,
+    "physical_processor": "Apple silicon M4 pro",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 48,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "mac1.metal",
+    "vCPU": 12,
+    "physical_processor": "Intel Core i7-8700B CPU",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 32,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "mac2-m1ultra.metal",
+    "vCPU": 20,
+    "physical_processor": "Apple silicon M1 Ultra",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 128,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "mac2-m2.metal",
+    "vCPU": 8,
+    "physical_processor": "Apple M2 Chip",
+    "clock_speed_ghz": "3.49 GHz",
+    "memory": 24,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "mac2-m2pro.metal",
+    "vCPU": 12,
+    "physical_processor": "Apple M2 Pro",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "mac2.metal",
+    "vCPU": 8,
+    "physical_processor": "Apple M1 chip with 8-core CPU, 8-core GPU, and 16-core Neural Engine",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 16,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "p2.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 732,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "p2.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 488,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "p2.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 61,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "p3.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 488,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "p3.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 61,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "p3.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 244,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "p3dn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175 (Skylake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "p4d.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 1152,
+    "network_performance": "4x 100 Gigabit"
+  },
+  {
+    "instance_type": "p4de.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8275L",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 1152,
+    "network_performance": "4x 100 Gigabit"
+  },
+  {
+    "instance_type": "p5.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 2048,
+    "network_performance": "3200 Gigabit"
+  },
+  {
+    "instance_type": "p5.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 256,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "p5e.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "2.95 GHz",
+    "memory": 2048,
+    "network_performance": "3200 Gigabit"
+  },
+  {
+    "instance_type": "p5en.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 2048,
+    "network_performance": "3200 Gigabit"
+  },
+  {
+    "instance_type": "p6-b200.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Emerald Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 2048,
+    "network_performance": "3200 Gigabit"
+  },
+  {
+    "instance_type": "p6e-gb200.36xlarge",
+    "vCPU": 144,
+    "physical_processor": "NVIDIA Grace",
+    "clock_speed_ghz": "3 GHz",
+    "memory": 960,
+    "network_performance": "1700 Gigabit"
+  },
+  {
+    "instance_type": "r3.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 61,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "r3.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 122,
+    "network_performance": "High"
+  },
+  {
+    "instance_type": "r3.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 244,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "r3.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 15.25,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "r3.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2670 v2 (Ivy Bridge)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 30.5,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "r4.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 488,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r4.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 61,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r4.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 122,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r4.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 244,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "r4.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 15.25,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r4.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon E5-2686 v4 (Broadwell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 30.5,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "r5.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 512,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "r5.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r5.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "r5.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r5.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "r5a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "r5a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 768,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "r5a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5ad.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "r5ad.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "r5ad.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 768,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "r5ad.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5ad.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5ad.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5ad.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5ad.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5b.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "r5b.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 512,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "r5b.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r5b.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5b.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5b.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "r5b.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5b.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r5b.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5d.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "r5d.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 512,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "r5d.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r5d.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5d.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5d.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "r5d.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5d.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r5d.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8175",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 512,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r5dn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r5n.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r5n.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "r5n.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r5n.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r5n.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r5n.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r5n.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r5n.metal",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 768,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r5n.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8259 (Cascade Lake)",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r6a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 384,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "r6a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r6a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 768,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "r6a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6a.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6a.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 128,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 256,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6a.metal",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7R13 Processor",
+    "clock_speed_ghz": "3.6 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "r6g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r6g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "r6g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6g.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r6g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r6gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "r6i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "r6i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r6i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 768,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "r6i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6i.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6i.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6id.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "r6id.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r6id.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 768,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "r6id.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6id.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6id.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6id.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6id.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6id.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6id.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 768,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 40 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "r6idn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "r6in.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 384,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "r6in.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r6in.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 768,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "r6in.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 40 Gigabit"
+  },
+  {
+    "instance_type": "r6in.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "r6in.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "r6in.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r6in.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r6in.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "r6in.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon 8375C (Ice Lake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "r7a.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 384,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "r7a.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r7a.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 768,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "r7a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7a.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r7a.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r7a.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 128,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7a.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 256,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7a.medium",
+    "vCPU": 1,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7a.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r7a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 9R14 Processor",
+    "clock_speed_ghz": "Up to 3.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "r7g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "r7g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r7g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r7g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "r7g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7g.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "r7g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 384,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "r7gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton3 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 384,
+    "network_performance": "18.75 Gigabit"
+  },
+  {
+    "instance_type": "r7i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r7i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 768,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "r7i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7i.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r7i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 128,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 256,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7i.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 768,
+    "network_performance": "37.5 Gigabit"
+  },
+  {
+    "instance_type": "r7i.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r7i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.2 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 384,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 128,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 256,
+    "network_performance": "12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.metal-16xl",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 512,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.metal-32xl",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r7iz.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "r8g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 512,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "r8g.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "r8g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8g.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r8g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 256,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "r8g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8g.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "r8g.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r8g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 384,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 512,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 256,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 8,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r8gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 384,
+    "network_performance": "150 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 512,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 768,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 64,
+    "network_performance": "Up to 50 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 1536,
+    "network_performance": "600 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 128,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 256,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 16,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 8,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 768,
+    "network_performance": "300 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 1536,
+    "network_performance": "600 Gigabit"
+  },
+  {
+    "instance_type": "r8gn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.8 GHz",
+    "memory": 32,
+    "network_performance": "Up to 40 Gigabit"
+  },
+  {
+    "instance_type": "r8i-flex.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 384,
+    "network_performance": "Up to 22.5 Gigabit"
+  },
+  {
+    "instance_type": "r8i-flex.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 512,
+    "network_performance": "Up to 30 Gigabit"
+  },
+  {
+    "instance_type": "r8i-flex.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8i-flex.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8i-flex.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 256,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8i-flex.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8i-flex.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8i.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 384,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "r8i.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 512,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "r8i.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 768,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "r8i.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 64,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8i.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "r8i.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 1536,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "r8i.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "r8i.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 256,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "r8i.96xlarge",
+    "vCPU": 384,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 3072,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r8i.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "r8i.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 1536,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "r8i.metal-96xl",
+    "vCPU": 384,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 3072,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "r8i.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Granite Rapids)",
+    "clock_speed_ghz": "3.9 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "t1.micro",
+    "vCPU": 1,
+    "physical_processor": "Variable",
+    "clock_speed_ghz": null,
+    "memory": 0.613,
+    "network_performance": "Very Low"
+  },
+  {
+    "instance_type": "t2.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "Up to 3.3 GHz",
+    "memory": 32,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "t2.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "Up to 3.3 GHz",
+    "memory": 8,
+    "network_performance": "Low to Moderate"
+  },
+  {
+    "instance_type": "t2.medium",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "Up to 3.3 GHz",
+    "memory": 4,
+    "network_performance": "Low to Moderate"
+  },
+  {
+    "instance_type": "t2.micro",
+    "vCPU": 1,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "Up to 3.3 GHz",
+    "memory": 1,
+    "network_performance": "Low to Moderate"
+  },
+  {
+    "instance_type": "t2.nano",
+    "vCPU": 1,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "Up to 3.3 GHz",
+    "memory": 0.5,
+    "network_performance": "Low to Moderate"
+  },
+  {
+    "instance_type": "t2.small",
+    "vCPU": 1,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "Up to 3.3 GHz",
+    "memory": 2,
+    "network_performance": "Low to Moderate"
+  },
+  {
+    "instance_type": "t2.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Family",
+    "clock_speed_ghz": "Up to 3.3 GHz",
+    "memory": 16,
+    "network_performance": "Moderate"
+  },
+  {
+    "instance_type": "t3.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Skylake E5 2686 v5",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 32,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Skylake E5 2686 v5",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 8,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3.medium",
+    "vCPU": 2,
+    "physical_processor": "Intel Skylake E5 2686 v5",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 4,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3.micro",
+    "vCPU": 2,
+    "physical_processor": "Intel Skylake E5 2686 v5",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 1,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3.nano",
+    "vCPU": 2,
+    "physical_processor": "Intel Skylake E5 2686 v5",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 0.5,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3.small",
+    "vCPU": 2,
+    "physical_processor": "Intel Skylake E5 2686 v5",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 2,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Skylake E5 2686 v5",
+    "clock_speed_ghz": "3.1 GHz",
+    "memory": 16,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3a.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3a.large",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3a.medium",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3a.micro",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 1,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3a.nano",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 0.5,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3a.small",
+    "vCPU": 2,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 2,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t3a.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AMD EPYC 7571",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t4g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t4g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 8,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t4g.medium",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 4,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t4g.micro",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 1,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t4g.nano",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 0.5,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t4g.small",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 2,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "t4g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 5 Gigabit"
+  },
+  {
+    "instance_type": "trn1.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "Up to 3.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "trn1.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "Up to 3.5 GHz",
+    "memory": 512,
+    "network_performance": "8x 100 Gigabit"
+  },
+  {
+    "instance_type": "trn1n.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "16x 100 Gigabit"
+  },
+  {
+    "instance_type": "trn2.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "Up to 3.9 GHz",
+    "memory": 2048,
+    "network_performance": "3200 Gigabit"
+  },
+  {
+    "instance_type": "u-12tb1.112xlarge",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Scalable (Skylake)",
+    "clock_speed_ghz": null,
+    "memory": 12288,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-12tb1.metal",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Scalable (Skylake)",
+    "clock_speed_ghz": null,
+    "memory": 12288,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-18tb1.112xlarge",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Platinum 8280L (Cascade Lake)",
+    "clock_speed_ghz": null,
+    "memory": 18432,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-18tb1.metal",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Platinum 8280L (Cascade Lake)",
+    "clock_speed_ghz": null,
+    "memory": 18432,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-24tb1.112xlarge",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Platinum 8280L (Cascade Lake)",
+    "clock_speed_ghz": null,
+    "memory": 24576,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-24tb1.metal",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Platinum 8280L (Cascade Lake)",
+    "clock_speed_ghz": null,
+    "memory": 24576,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-3tb1.56xlarge",
+    "vCPU": 224,
+    "physical_processor": "Intel Xeon Scalable (Skylake)",
+    "clock_speed_ghz": "2.1 GHz",
+    "memory": 3072,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "u-6tb1.112xlarge",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Scalable (Skylake)",
+    "clock_speed_ghz": null,
+    "memory": 6144,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-6tb1.56xlarge",
+    "vCPU": 224,
+    "physical_processor": "Intel Xeon Scalable (Skylake)",
+    "clock_speed_ghz": null,
+    "memory": 6144,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-6tb1.metal",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Scalable (Skylake)",
+    "clock_speed_ghz": null,
+    "memory": 6144,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-9tb1.112xlarge",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Scalable (Skylake)",
+    "clock_speed_ghz": null,
+    "memory": 9216,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u-9tb1.metal",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Scalable (Skylake)",
+    "clock_speed_ghz": null,
+    "memory": 9216,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u7i-12tb.224xlarge",
+    "vCPU": 896,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 12288,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u7i-6tb.112xlarge",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 6144,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u7i-8tb.112xlarge",
+    "vCPU": 448,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 8192,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "u7in-16tb.224xlarge",
+    "vCPU": 896,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 16384,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "u7in-24tb.224xlarge",
+    "vCPU": 896,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 24576,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "u7in-32tb.224xlarge",
+    "vCPU": 896,
+    "physical_processor": "Intel Xeon Scalable (Sapphire Rapids)",
+    "clock_speed_ghz": "2.9 GHz",
+    "memory": 32768,
+    "network_performance": "200 Gigabit"
+  },
+  {
+    "instance_type": "vt1.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Platinum 8259CL",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 192,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "vt1.3xlarge",
+    "vCPU": 12,
+    "physical_processor": "Intel Xeon Platinum 8259CL",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 24,
+    "network_performance": "3.12 Gigabit"
+  },
+  {
+    "instance_type": "vt1.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "Intel Xeon Platinum 8259CL",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 48,
+    "network_performance": "6.25 Gigabit"
+  },
+  {
+    "instance_type": "x1.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "High Frequency Intel Xeon E7-8880 v3 (Haswell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 976,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "x1.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "High Frequency Intel Xeon E7-8880 v3 (Haswell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 1952,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "x1e.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "High Frequency Intel Xeon E7-8880 v3 (Haswell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 1952,
+    "network_performance": "10 Gigabit"
+  },
+  {
+    "instance_type": "x1e.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "High Frequency Intel Xeon E7-8880 v3 (Haswell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 244,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x1e.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "High Frequency Intel Xeon E7-8880 v3 (Haswell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 3904,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "x1e.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "High Frequency Intel Xeon E7-8880 v3 (Haswell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 488,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x1e.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "High Frequency Intel Xeon E7-8880 v3 (Haswell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 976,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x1e.xlarge",
+    "vCPU": 4,
+    "physical_processor": "High Frequency Intel Xeon E7-8880 v3 (Haswell)",
+    "clock_speed_ghz": "2.3 GHz",
+    "memory": 122,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 768,
+    "network_performance": "20 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 1024,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 256,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 512,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.metal",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 1024,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "x2gd.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton2 Processor",
+    "clock_speed_ghz": "2.5 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "x2idn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "x2idn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1536,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "x2idn.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 2048,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "x2idn.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 2048,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "x2iedn.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 2048,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "x2iedn.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 3072,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "x2iedn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 256,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "x2iedn.32xlarge",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 4096,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "x2iedn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 512,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "x2iedn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 1024,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "x2iedn.metal",
+    "vCPU": 128,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 4096,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "x2iedn.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Scalable (Icelake)",
+    "clock_speed_ghz": "3.5 GHz",
+    "memory": 128,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "x2iezn.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 1536,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "x2iezn.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 256,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "x2iezn.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 512,
+    "network_performance": "Up to 25 Gigabit"
+  },
+  {
+    "instance_type": "x2iezn.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 768,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "x2iezn.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 1024,
+    "network_performance": "75 Gigabit"
+  },
+  {
+    "instance_type": "x2iezn.metal",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8252",
+    "clock_speed_ghz": "4.5 GHz",
+    "memory": 1536,
+    "network_performance": "100 Gigabit"
+  },
+  {
+    "instance_type": "x8g.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 768,
+    "network_performance": "22.5 Gigabit"
+  },
+  {
+    "instance_type": "x8g.16xlarge",
+    "vCPU": 64,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1024,
+    "network_performance": "30 Gigabit"
+  },
+  {
+    "instance_type": "x8g.24xlarge",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "x8g.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 128,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "x8g.48xlarge",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 3072,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "x8g.4xlarge",
+    "vCPU": 16,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 256,
+    "network_performance": "Up to 15 Gigabit"
+  },
+  {
+    "instance_type": "x8g.8xlarge",
+    "vCPU": 32,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 512,
+    "network_performance": "15 Gigabit"
+  },
+  {
+    "instance_type": "x8g.large",
+    "vCPU": 2,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 32,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "x8g.medium",
+    "vCPU": 1,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 16,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "x8g.metal-24xl",
+    "vCPU": 96,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 1536,
+    "network_performance": "40 Gigabit"
+  },
+  {
+    "instance_type": "x8g.metal-48xl",
+    "vCPU": 192,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 3072,
+    "network_performance": "50 Gigabit"
+  },
+  {
+    "instance_type": "x8g.xlarge",
+    "vCPU": 4,
+    "physical_processor": "AWS Graviton4 Processor",
+    "clock_speed_ghz": "2.7 GHz",
+    "memory": 64,
+    "network_performance": "Up to 12.5 Gigabit"
+  },
+  {
+    "instance_type": "z1d.12xlarge",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8151",
+    "clock_speed_ghz": "4 GHz",
+    "memory": 384,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "z1d.2xlarge",
+    "vCPU": 8,
+    "physical_processor": "Intel Xeon Platinum 8151",
+    "clock_speed_ghz": "4 GHz",
+    "memory": 64,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "z1d.3xlarge",
+    "vCPU": 12,
+    "physical_processor": "Intel Xeon Platinum 8151",
+    "clock_speed_ghz": "4 GHz",
+    "memory": 96,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "z1d.6xlarge",
+    "vCPU": 24,
+    "physical_processor": "Intel Xeon Platinum 8151",
+    "clock_speed_ghz": "4 GHz",
+    "memory": 192,
+    "network_performance": "12 Gigabit"
+  },
+  {
+    "instance_type": "z1d.large",
+    "vCPU": 2,
+    "physical_processor": "Intel Xeon Platinum 8151",
+    "clock_speed_ghz": "4 GHz",
+    "memory": 16,
+    "network_performance": "Up to 10 Gigabit"
+  },
+  {
+    "instance_type": "z1d.metal",
+    "vCPU": 48,
+    "physical_processor": "Intel Xeon Platinum 8151",
+    "clock_speed_ghz": "4 GHz",
+    "memory": 384,
+    "network_performance": "25 Gigabit"
+  },
+  {
+    "instance_type": "z1d.xlarge",
+    "vCPU": 4,
+    "physical_processor": "Intel Xeon Platinum 8151",
+    "clock_speed_ghz": "4 GHz",
+    "memory": 32,
+    "network_performance": "Up to 10 Gigabit"
+  }
+]

--- a/data/fetch_aws_ec2_metadata.py
+++ b/data/fetch_aws_ec2_metadata.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Script to fetch and parse instances.json to create a distilled version containing only specific fields.
+"""
+
+import json
+import sys
+import os
+import subprocess
+import tempfile
+
+
+def fetch_fresh_instances():
+    """
+    Fetch fresh instances.json from the source URL and return the data directly.
+    All downloaded files are automatically cleaned up.
+    
+    Returns:
+        list: Parsed instances data
+    """
+    url = "https://instances.vantagestaging.sh/www_pre_build.tar.gz"
+    
+    print(f"Fetching fresh instances data from: {url}")
+    
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            print("Downloading and extracting data...")
+            
+            cmd = f"curl -L {url} | tar -xzf - -C {temp_dir}"
+            result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+            
+            if result.returncode != 0:
+                raise Exception(f"Failed to fetch data: {result.stderr}")
+
+            instances_file = os.path.join(temp_dir, "www", "instances.json")
+            
+            if not os.path.exists(instances_file):
+                raise Exception("instances.json not found at expected path: www/instances.json")
+            
+            print("Parsing instances data...")
+            with open(instances_file, 'r', encoding='utf-8') as f:
+                instances = json.load(f)
+            
+            print(f"Successfully fetched and parsed {len(instances)} instances")
+            return instances
+            
+    except subprocess.CalledProcessError as e:
+        raise Exception(f"Network error while fetching data: {e}")
+    except Exception as e:
+        raise Exception(f"Error fetching fresh instances data: {e}")
+
+
+def parse_instances(instances_data, output_file):
+    """
+    Parse instances data and extract only the specified fields.
+    
+    Args:
+        instances_data (list): List of instance dictionaries
+        output_file (str): Path to the output distilled JSON file
+    """
+    # Fields to keep
+    required_fields = [
+        'instance_type',
+        'vCPU',
+        'physical_processor',
+        'clock_speed_ghz',
+        'memory',
+        'network_performance'
+    ]
+    
+    try:
+        print(f"Processing {len(instances_data)} instances")
+        
+        distilled_instances = []
+        
+        for instance in instances_data:
+            distilled_instance = {}
+            
+            for field in required_fields:
+                if field in instance:
+                    distilled_instance[field] = instance[field]
+                else:
+                    # Handle missing fields gracefully
+                    distilled_instance[field] = None
+            
+            distilled_instances.append(distilled_instance)
+        
+        with open(output_file, 'w', encoding='utf-8') as f:
+            json.dump(distilled_instances, f, indent=2, ensure_ascii=False)
+        
+        print(f"Successfully created distilled instances file: {output_file}")
+        print(f"Extracted {len(distilled_instances)} instances with {len(required_fields)} fields each")
+        
+        print("\nSample of first 3 distilled instances:")
+        for i, instance in enumerate(distilled_instances[:3]):
+            print(f"\nInstance {i+1}:")
+            for field, value in instance.items():
+                print(f"  {field}: {value}")
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+def main():
+    """Main function to fetch fresh AWS EC2 instances data and create distilled output."""
+    import argparse
+    
+    parser = argparse.ArgumentParser(
+        description="Fetch fresh AWS EC2 instances data and create a distilled version with specific fields",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python fetch_aws_ec2_metadata.py aws_ec2_instances.json
+  python fetch_aws_ec2_metadata.py /tmp/aws_ec2_instances.json
+        """
+    )
+    
+    parser.add_argument(
+        'output_file',
+        help='Path to output distilled JSON file'
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        print("Fetching fresh instances data...")
+        instances_data = fetch_fresh_instances()
+        
+        parse_instances(instances_data, args.output_file)
+        
+        print("All temporary files have been automatically cleaned up.")
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/fetch_aws_ec2_metadata.py
+++ b/data/fetch_aws_ec2_metadata.py
@@ -8,11 +8,13 @@ import sys
 import os
 import subprocess
 import tempfile
+import logging
 
+logger = logging.getLogger("metadata-fetcher")
 
 def fetch_fresh_instances():
     """
-    Fetch fresh instances.json from the source URL and return the data directly.
+    Fetch fresh instances.json from the source URL.
     All downloaded files are automatically cleaned up.
     
     Returns:
@@ -20,11 +22,11 @@ def fetch_fresh_instances():
     """
     url = "https://instances.vantagestaging.sh/www_pre_build.tar.gz"
     
-    print(f"Fetching fresh instances data from: {url}")
+    logger.info(f"Fetching fresh instances data from: {url}")
     
     try:
         with tempfile.TemporaryDirectory() as temp_dir:
-            print("Downloading and extracting data...")
+            logger.info("Downloading and extracting data...")
             
             cmd = f"curl -L {url} | tar -xzf - -C {temp_dir}"
             result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
@@ -37,11 +39,11 @@ def fetch_fresh_instances():
             if not os.path.exists(instances_file):
                 raise Exception("instances.json not found at expected path: www/instances.json")
             
-            print("Parsing instances data...")
+            logger.info("Parsing instances data...")
             with open(instances_file, 'r', encoding='utf-8') as f:
                 instances = json.load(f)
             
-            print(f"Successfully fetched and parsed {len(instances)} instances")
+            logger.info(f"Successfully fetched and parsed {len(instances)} instances")
             return instances
             
     except subprocess.CalledProcessError as e:
@@ -69,7 +71,7 @@ def parse_instances(instances_data, output_file):
     ]
     
     try:
-        print(f"Processing {len(instances_data)} instances")
+        logger.info(f"Processing {len(instances_data)} instances")
         
         distilled_instances = []
         
@@ -88,17 +90,17 @@ def parse_instances(instances_data, output_file):
         with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(distilled_instances, f, indent=2, ensure_ascii=False)
         
-        print(f"Successfully created distilled instances file: {output_file}")
-        print(f"Extracted {len(distilled_instances)} instances with {len(required_fields)} fields each")
+        logger.info(f"Successfully created distilled instances file: {output_file}")
+        logger.info(f"Extracted {len(distilled_instances)} instances with {len(required_fields)} fields each")
         
-        print("\nSample of first 3 distilled instances:")
+        logger.info("\nSample of first 3 distilled instances:")
         for i, instance in enumerate(distilled_instances[:3]):
-            print(f"\nInstance {i+1}:")
+            logger.info(f"\nInstance {i+1}:")
             for field, value in instance.items():
-                print(f"  {field}: {value}")
+                logger.info(f"  {field}: {value}")
         
     except Exception as e:
-        print(f"Error: {e}")
+        logger.error(f"Error: {e}")
         sys.exit(1)
 
 
@@ -124,15 +126,15 @@ Examples:
     args = parser.parse_args()
     
     try:
-        print("Fetching fresh instances data...")
+        logger.info("Fetching fresh instances data...")
         instances_data = fetch_fresh_instances()
         
         parse_instances(instances_data, args.output_file)
         
-        print("All temporary files have been automatically cleaned up.")
+        logger.info("Done!")
         
     except Exception as e:
-        print(f"Error: {e}")
+        logger.error(f"Error: {e}")
         sys.exit(1)
 
 

--- a/data_collector/collector.py
+++ b/data_collector/collector.py
@@ -3,6 +3,7 @@ import time
 from opensearchpy import OpenSearch
 from opensearch_dsl import Search, Q
 from datetime import datetime
+from data_collector.instance_mapper import InstanceMapper
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,7 @@ class Collector:
         self.config = config
         self.es_index = es_index
         self.os_client = OpenSearch(es_server, verify_certs=False, http_compress=True, timeout=30)
+        self.instance_mapper = InstanceMapper()
         logging.getLogger("opensearch").setLevel(logging.WARNING)
 
     def collect(self, from_date: datetime, to: datetime):
@@ -78,6 +80,10 @@ class Collector:
                             run_data[uuid]["metadata"][field] = jobSummary[field]
                         elif "jobConfig" in jobSummary and field in jobSummary["jobConfig"]:
                             run_data[uuid]["metadata"].setdefault("jobConfig", {})[field] = jobSummary["jobConfig"][field]
+ 
+                    # Append instance specifications to existing metadata
+                    instance_specs = self.instance_mapper.map_instance_types_from_metadata(run_data[uuid]["metadata"])
+                    run_data[uuid]["metadata"].update(instance_specs)
 
                     metrics, count_verified = self._metrics_by_uuid(uuid)
                     if count_verified:

--- a/data_collector/instance_mapper.py
+++ b/data_collector/instance_mapper.py
@@ -1,0 +1,109 @@
+"""
+Functionality for mapping AWS EC2 instance types to specifications.
+"""
+
+import json
+import logging
+from typing import Dict, Optional, Any
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class InstanceMapper:
+    """Maps AWS EC2 instance types to their specifications."""
+    
+    def __init__(self, aws_instances_file: str = "data/aws_ec2_instances.json"):
+        """
+        Initialize the instance mapper with AWS EC2 instances data.
+        
+        Args:
+            aws_instances_file: Path to the AWS EC2 instances JSON file
+        """
+        self.aws_instances_file = aws_instances_file
+        self.instance_specs = {}
+        self._load_aws_instances()
+    
+    def _load_aws_instances(self) -> None:
+        """Load AWS EC2 instances data from JSON file."""
+        try:
+            # Get the project root directory
+            project_root = Path(__file__).parent.parent
+            instances_path = project_root / self.aws_instances_file
+            
+            if not instances_path.exists():
+                raise FileNotFoundError(f"AWS instances file not found: {instances_path}")
+            
+            with open(instances_path, 'r', encoding='utf-8') as f:
+                instances_data = json.load(f)
+            
+            # Create a lookup dictionary for faster access
+            for instance in instances_data:
+                instance_type = instance.get('instance_type')
+                if instance_type:
+                    self.instance_specs[instance_type] = {
+                        'vCPU': instance.get('vCPU'),
+                        'physical_processor': instance.get('physical_processor'),
+                        'clock_speed_ghz': instance.get('clock_speed_ghz'),
+                        'memory': instance.get('memory'),
+                        'network_performance': instance.get('network_performance')
+                    }
+            
+            logger.info(f"Loaded {len(self.instance_specs)} AWS instance specifications")
+            
+        except Exception as e:
+            logger.error(f"Failed to load AWS instances data: {e}")
+            raise
+    
+    def get_instance_specs(self, instance_type: str) -> Optional[Dict[str, Any]]:
+        """
+        Get specifications for a given instance type.
+        
+        Args:
+            instance_type: AWS instance type (e.g., 'm6a.xlarge')
+            
+        Returns:
+            Dictionary containing instance specifications
+        """
+        return self.instance_specs.get(instance_type)
+    
+    
+    def map_instance_types_from_metadata(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Map instance types from metadata (flattened data structure).
+        
+        Args:
+            metadata: Flattened metadata containing instance type information
+            
+        Returns:
+            Dictionary with mapped instance specifications in flat structure
+        """
+        mapped_data = {}
+        
+        # Define node types and their prefixes
+        node_types = [
+            ('masterNodesType', 'masterNode'),
+            ('workerNodesType', 'workerNode'),
+            ('infraNodesType', 'infraNode')
+        ]
+        
+        # Map each node type
+        for node_type_key, prefix in node_types:
+            instance_type = metadata.get(node_type_key)
+            if instance_type:
+                specs = self.get_instance_specs(instance_type)
+                if specs:
+                    mapped_data[f'{prefix}vCPU'] = specs.get('vCPU')
+                    mapped_data[f'{prefix}PhysicalProcessor'] = specs.get('physical_processor')
+                    mapped_data[f'{prefix}ClockSpeedGhz'] = specs.get('clock_speed_ghz')
+                    mapped_data[f'{prefix}Memory'] = specs.get('memory')
+                    mapped_data[f'{prefix}NetworkPerformance'] = specs.get('network_performance')
+                else:
+                    logger.warning(f"{prefix} instance type '{instance_type}' not found in AWS instances data")
+                    mapped_data[f'{prefix}vCPU'] = None
+                    mapped_data[f'{prefix}PhysicalProcessor'] = None
+                    mapped_data[f'{prefix}ClockSpeedGhz'] = None
+                    mapped_data[f'{prefix}Memory'] = None
+                    mapped_data[f'{prefix}NetworkPerformance'] = None
+        
+        return mapped_data

--- a/data_collector/instance_mapper.py
+++ b/data_collector/instance_mapper.py
@@ -13,23 +13,21 @@ logger = logging.getLogger(__name__)
 class InstanceMapper:
     """Maps AWS EC2 instance types to their specifications."""
     
-    def __init__(self, aws_instances_file: str = "data/aws_ec2_instances.json"):
+    def __init__(self, aws_instances_file_path: str = None):
         """
         Initialize the instance mapper with AWS EC2 instances data.
         
         Args:
             aws_instances_file: Path to the AWS EC2 instances JSON file
         """
-        self.aws_instances_file = aws_instances_file
+        self.aws_instances_file_path = aws_instances_file_path
         self.instance_specs = {}
         self._load_aws_instances()
     
     def _load_aws_instances(self) -> None:
         """Load AWS EC2 instances data from JSON file."""
         try:
-            # Get the project root directory
-            project_root = Path(__file__).parent.parent
-            instances_path = project_root / self.aws_instances_file
+            instances_path = Path(self.aws_instances_file_path)
             
             if not instances_path.exists():
                 raise FileNotFoundError(f"AWS instances file not found: {instances_path}")
@@ -37,7 +35,6 @@ class InstanceMapper:
             with open(instances_path, 'r', encoding='utf-8') as f:
                 instances_data = json.load(f)
             
-            # Create a lookup dictionary for faster access
             for instance in instances_data:
                 instance_type = instance.get('instance_type')
                 if instance_type:
@@ -70,24 +67,22 @@ class InstanceMapper:
     
     def map_instance_types_from_metadata(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Map instance types from metadata (flattened data structure).
+        Map instance types from metadata.
         
         Args:
-            metadata: Flattened metadata containing instance type information
+            metadata: Metadata containing instance type information
             
         Returns:
-            Dictionary with mapped instance specifications in flat structure
+            Dictionary with mapped instance specifications
         """
         mapped_data = {}
         
-        # Define node types and their prefixes
         node_types = [
             ('masterNodesType', 'masterNode'),
             ('workerNodesType', 'workerNode'),
             ('infraNodesType', 'infraNode')
         ]
         
-        # Map each node type
         for node_type_key, prefix in node_types:
             instance_type = metadata.get(node_type_key)
             if instance_type:

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from data_collector.utils import split_list_into_chunks, parse_timerange
 from data_collector.constants import S3_BUCKET, CHUNK_SIZE, VALID_LOG_LEVELS
 from data_collector.logging import configure_logging
 import datetime
+from data_collector.instance_mapper import InstanceMapper
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -33,6 +34,7 @@ def main():
     collect.add_argument("--es-server", action="store", help="ES Server endpoint", required=True)
     collect.add_argument("--es-index", action="store", help="ES Index name", required=True)
     collect.add_argument("--config", action="store", help="Configuration file")
+    collect.add_argument("--instance-dict", action="store", help="Instance dictionary file")
     collect.add_argument(
         "--from",
         action="store",
@@ -58,7 +60,13 @@ def main():
         config = Config(args.config)
         logger.debug(f"Processing input configuration: {config}")
         input_config = config.parse()
-        collector_instance = collector.Collector(args.es_server, args.es_index, input_config)
+        if args.instance_dict:
+            logger.info(f"Instance dictionary file provided: {args.instance_dict}")
+            instance_mapper = InstanceMapper(args.instance_dict)
+        else:
+            logger.warning("No instance dictionary file provided, hardware specs won't be populated")
+            instance_mapper = None
+        collector_instance = collector.Collector(args.es_server, args.es_index, input_config, instance_mapper)
         data = collector_instance.collect(from_date, to)
         for each_run in data:
             for _, run_json in each_run.items():


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a comprehensive list of AWS EC2 instances mapped to their specs along with a script to re-populate this list. This mapping is used to populate the following metadata fields for each node pool (master, worker, infra):
 * vCPU
 * PhysicalProcessor
 * ClockSpeedGhz
 * Memory
 * NetworkPerformance

The metadata population is optional, it must be enabled via the `--instance-dict` flag that points to the instance to specs mapping file.

## Related Tickets & Documents

- PERFSCALE-4123

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
